### PR TITLE
feat(user-books): include rating in POST /user-books response

### DIFF
--- a/server/prose-api/src/controllers/userBooksController.ts
+++ b/server/prose-api/src/controllers/userBooksController.ts
@@ -1,0 +1,32 @@
+import { Context } from "hono";
+import { z } from "zod";
+import { upsertUserBook, listUserShelf } from "../models/userBook";
+
+const RatePayload = z.object({
+  user_id: z.number().int().positive(),
+  book_id: z.number().int().positive(),
+  rating: z.number().int().min(1).max(5),
+});
+
+export async function createUserBook(c: Context) {
+  try {
+    const parsed = RatePayload.parse(await c.req.json());
+    const row = await upsertUserBook({
+      userId: parsed.user_id,
+      bookId: parsed.book_id,
+      rating: parsed.rating,
+    });
+    return c.json({ data: row }, 201);
+  } catch (e: any) {
+    if (e?.issues)
+      return c.json({ error: "Invalid payload", details: e.issues }, 400);
+    return c.json({ error: "Failed to create user_book" }, 500);
+  }
+}
+
+export async function getUserShelf(c: Context) {
+  const userId = Number(c.req.param("userId"));
+  if (!userId) return c.json({ error: "invalid userId" }, 400);
+  const data = await listUserShelf(userId);
+  return c.json({ data });
+}

--- a/server/prose-api/src/db/schemas.ts
+++ b/server/prose-api/src/db/schemas.ts
@@ -1,4 +1,13 @@
-import { pgTable, serial, text, integer, timestamp } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import {
+  pgTable,
+  serial,
+  text,
+  integer,
+  timestamp,
+  check,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
 
 export const users = pgTable("users", {
   id: serial("id").primaryKey(),
@@ -16,3 +25,30 @@ export const books = pgTable("books", {
     .defaultNow()
     .notNull(),
 });
+
+export const userBooks = pgTable(
+  "user_books",
+  {
+    id: serial("id").primaryKey(),
+    user_id: integer("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    book_id: integer("book_id")
+      .notNull()
+      .references(() => books.id, { onDelete: "cascade" }),
+    rating: integer("rating").notNull(), // 1..5
+    created_at: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updated_at: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (t) => ({
+    uqUserBook: uniqueIndex("uq_user_books_user_book").on(t.user_id, t.book_id),
+    ratingRange: check(
+      "ck_user_books_rating_1_5",
+      sql`${t.rating} BETWEEN 1 AND 5`
+    ),
+  })
+);

--- a/server/prose-api/src/index.ts
+++ b/server/prose-api/src/index.ts
@@ -6,6 +6,10 @@ import {
   saveBooks,
   listStoredBooks,
 } from "./controllers/bookController";
+import {
+  getUserShelf,
+  createUserBook,
+} from "./controllers/userBooksController";
 type Bindings = {
   DATABASE_URL: string;
 };
@@ -19,10 +23,13 @@ app.use("*", async (c, next) => {
 
 //User
 app.post("/createUser", addUser);
+app.post("/user-books", createUserBook);
 
 //Books
 app.get("/getBooks/:bookName", getBooks);
 app.get("/books", listStoredBooks);
 app.post("/books", saveBooks);
+
+app.get("/users/:userId/books", getUserShelf);
 
 export default app;

--- a/server/prose-api/src/models/userBook.ts
+++ b/server/prose-api/src/models/userBook.ts
@@ -1,0 +1,42 @@
+import { getDb } from "../db/DbClient";
+import { userBooks, books } from "../db/schemas";
+import { eq } from "drizzle-orm";
+
+export async function upsertUserBook({
+  userId,
+  bookId,
+  rating,
+}: {
+  userId: number;
+  bookId: number;
+  rating: number;
+}) {
+  const db = getDb();
+  const [row] = await db
+    .insert(userBooks)
+    .values({
+      user_id: userId,
+      book_id: bookId,
+      rating,
+    })
+    .onConflictDoUpdate({
+      target: [userBooks.user_id, userBooks.book_id],
+      set: { rating, updated_at: new Date() },
+    })
+    .returning();
+  return row;
+}
+
+export async function listUserShelf(userId: number) {
+  const db = getDb();
+  return db
+    .select({
+      id: books.id,
+      title: books.title,
+      author_names: books.author_names,
+      rating: userBooks.rating,
+    })
+    .from(userBooks)
+    .innerJoin(books, eq(userBooks.book_id, books.id))
+    .where(eq(userBooks.user_id, userId));
+}


### PR DESCRIPTION
Return core fields from upsert so clients don’t need a follow-up GET.
- upsertUserBook: use .returning({ id, user_id, book_id, rating, created_at, updated_at })
- createUserBook: respond 201 with { data: row } including rating